### PR TITLE
Don't compare to hard-coded AUC values, issue #340

### DIFF
--- a/tests/testthat/test-develop-supervised-model.R
+++ b/tests/testthat/test-develop-supervised-model.R
@@ -45,6 +45,7 @@ test_that("Error is thrown when predicted column is binary and type is regressio
 
 test_that("AUC_lmm is the same each time the test is run", {
 
+  skip_on_cran()
   p <- initializeParamsForTesting(df)
   p$type = 'classification'
   p$personCol = 'PatientID'
@@ -59,6 +60,7 @@ test_that("AUC_lmm is the same each time the test is run", {
 
 test_that("rmse_lmm is the same each time the test is run", {
 
+  skip_on_cran()
   p <- initializeParamsForTesting(df)
   p$type = 'regression'
   p$personCol = 'PatientID'
@@ -73,6 +75,7 @@ test_that("rmse_lmm is the same each time the test is run", {
 
 test_that("mae_lmm is the same each time the test is run", {
 
+  skip_on_cran()
   p <- initializeParamsForTesting(df)
   p$type = 'regression'
   p$personCol = 'PatientID'
@@ -91,6 +94,7 @@ test_that("mae_lmm is the same each time the test is run", {
 test_that("AUC_lasso is the same each time the test is run", {
   df$PatientID <- NULL #<- Note this happens affects all following tests
 
+  skip_on_cran()
   p <- initializeParamsForTesting(df)
   p$df = df
   p$type = 'classification'
@@ -104,6 +108,7 @@ test_that("AUC_lasso is the same each time the test is run", {
 
 test_that("rmse_lasso is the same each time the test is run non-factor column", {
 
+  skip_on_cran()
   p <- initializeParamsForTesting(df)
   p$type = 'regression'
   p$predictedCol = 'A1CNBR'
@@ -117,6 +122,7 @@ test_that("rmse_lasso is the same each time the test is run non-factor column", 
 
 test_that("mae_lasso is the same each time the test is run non-factor column", {
 
+  skip_on_cran()
   p <- initializeParamsForTesting(df)
   p$type = 'regression'
   p$predictedCol = 'A1CNBR'
@@ -133,6 +139,7 @@ test_that("mae_lasso is the same each time the test is run non-factor column", {
 
 test_that("AUC_rf is the same each time the test is run", {
   
+  skip_on_cran()
   p <- initializeParamsForTesting(df)
   p$type = 'classification'
   p$predictedCol = 'ThirtyDayReadmitFLG'
@@ -146,6 +153,7 @@ test_that("AUC_rf is the same each time the test is run", {
 
 test_that("rmse_rf is the same each time the test is run non-factor column", {
 
+  skip_on_cran()
   p <- initializeParamsForTesting(df)
   p$type = 'regression'
   p$predictedCol = 'A1CNBR'
@@ -159,6 +167,7 @@ test_that("rmse_rf is the same each time the test is run non-factor column", {
 
 test_that("mae_rf is the same each time the test is run non-factor column", {
 
+  skip_on_cran()
   p <- initializeParamsForTesting(df)
   p$type = 'regression'
   p$predictedCol = 'A1CNBR'


### PR DESCRIPTION
Add `skip_on_cran()` to all "is the same each time the test is run" tests.